### PR TITLE
Move to JobIntentService

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,9 +32,11 @@
 
         <service
             android:name=".services.MySimpleService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false" />
         <service
             android:name=".services.ImageDownloadService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="true" />
 
         <receiver

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,8 +40,7 @@
             android:exported="true" />
 
         <receiver
-            android:name=".receivers.MyAlarmReceiver"
-            android:process=":remote"></receiver>
+            android:name=".receivers.MyAlarmReceiver"></receiver>
 
         <service
             android:name=".services.DirectReplyIntent"></service>

--- a/app/src/main/java/com/codepath/example/servicesnotificationsdemo/activities/MainActivity.java
+++ b/app/src/main/java/com/codepath/example/servicesnotificationsdemo/activities/MainActivity.java
@@ -43,7 +43,7 @@ public class MainActivity extends Activity {
 		i.putExtra("foo", "bar");
 		i.putExtra("receiver", receiverForSimple);
 		// Start the service
-		startService(i); 
+		MySimpleService.enqueueWork(this, i);
 	}
 	
 	public void onImageDownloadService(View v) {
@@ -52,7 +52,7 @@ public class MainActivity extends Activity {
 		// Add extras to bundle
 		i.putExtra("url", "http://www.zastavki.com/pictures/1920x1200/2010/World_Australia_River_in_Australia_022164_.jpg");
 		// Start the service
-		startService(i);
+		ImageDownloadService.enqueueWork(this, i);
 	}
 	
 	public void onStartAlarm(View v) {

--- a/app/src/main/java/com/codepath/example/servicesnotificationsdemo/activities/MainActivity.java
+++ b/app/src/main/java/com/codepath/example/servicesnotificationsdemo/activities/MainActivity.java
@@ -25,7 +25,6 @@ public class MainActivity extends Activity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_main);
-		setupServiceReceiver();
 		checkForMessage();
 	}
 
@@ -41,7 +40,7 @@ public class MainActivity extends Activity {
 		Intent i = new Intent(this, MySimpleService.class);
 		// Add extras to the bundle
 		i.putExtra("foo", "bar");
-		i.putExtra("receiver", receiverForSimple);
+		i.putExtra("receiver", MySimpleReceiver.setupServiceReceiver(MainActivity.this));
 		// Start the service
 		MySimpleService.enqueueWork(this, i);
 	}
@@ -58,15 +57,15 @@ public class MainActivity extends Activity {
 	public void onStartAlarm(View v) {
 		// Construct an intent that will execute the AlarmReceiver
 	    Intent intent = new Intent(getApplicationContext(), MyAlarmReceiver.class);
-	    intent.putExtra("receiver", receiverForSimple);
 	    // Create a PendingIntent to be triggered when the alarm goes off
 	    alarmPendingIntent = PendingIntent.getBroadcast(this, MyAlarmReceiver.REQUEST_CODE,
 	        intent, PendingIntent.FLAG_UPDATE_CURRENT);
 	    // Setup periodic alarm every 5 seconds
 	    long firstMillis = System.currentTimeMillis(); // first run of alarm is immediate
-	    int intervalMillis = 5000; // 5 seconds
+	    int intervalMillis = 60000; // as of API 19, alarm manager will be forced up to 60000 to save battery
 	    AlarmManager alarm = (AlarmManager) this.getSystemService(Context.ALARM_SERVICE);
-	    alarm.setInexactRepeating(AlarmManager.RTC_WAKEUP, firstMillis, intervalMillis, alarmPendingIntent);
+	    // See https://developer.android.com/training/scheduling/alarms.html
+		alarm.setInexactRepeating(AlarmManager.RTC_WAKEUP, firstMillis, intervalMillis, alarmPendingIntent);
 	}
 	
 	public void onStopAlarm(View v) {
@@ -74,22 +73,6 @@ public class MainActivity extends Activity {
 		if (alarmPendingIntent != null) {
 		  alarm.cancel(alarmPendingIntent);
 		}
-	}
-
-	// Setup the callback for when data is received from the service
-	public void setupServiceReceiver() {
-		receiverForSimple = new MySimpleReceiver(new Handler());
-		// This is where we specify what happens when data is received from the
-		// service
-		receiverForSimple.setReceiver(new MySimpleReceiver.Receiver() {
-			@Override
-			public void onReceiveResult(int resultCode, Bundle resultData) {
-				if (resultCode == RESULT_OK) {
-					String resultValue = resultData.getString("resultValue");
-					Toast.makeText(MainActivity.this, resultValue, Toast.LENGTH_SHORT).show();
-				}
-			}
-		});
 	}
 	
 	// Checks to see if service passed in a message

--- a/app/src/main/java/com/codepath/example/servicesnotificationsdemo/receivers/MyAlarmReceiver.java
+++ b/app/src/main/java/com/codepath/example/servicesnotificationsdemo/receivers/MyAlarmReceiver.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.ResultReceiver;
+import android.util.Log;
 
 import com.codepath.example.servicesnotificationsdemo.services.MySimpleService;
 
@@ -14,10 +15,11 @@ public class MyAlarmReceiver extends BroadcastReceiver {
 	// Triggered by the Alarm periodically (starts the service to run task)
 	@Override
 	public void onReceive(Context context, Intent intent) {
+		Log.d("DEBUG", "MyAlarmReceiver triggered");
+
 		Intent i = new Intent(context, MySimpleService.class);
-		ResultReceiver receiver = intent.getParcelableExtra("receiver");
 		i.putExtra("foo", "alarm!!");
-		i.putExtra("receiver", receiver); 
-		context.startService(i); 
+		i.putExtra("receiver", MySimpleReceiver.setupServiceReceiver(context));
+		MySimpleService.enqueueWork(context, i);
 	}
 }

--- a/app/src/main/java/com/codepath/example/servicesnotificationsdemo/receivers/MySimpleReceiver.java
+++ b/app/src/main/java/com/codepath/example/servicesnotificationsdemo/receivers/MySimpleReceiver.java
@@ -1,8 +1,14 @@
 package com.codepath.example.servicesnotificationsdemo.receivers;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.ResultReceiver;
+import android.widget.Toast;
+
+import com.codepath.example.servicesnotificationsdemo.activities.MainActivity;
+
+import static android.app.Activity.RESULT_OK;
 
 //Defines a generic receiver used to pass data to Activity from a Service
 public class MySimpleReceiver extends ResultReceiver {
@@ -21,6 +27,23 @@ public class MySimpleReceiver extends ResultReceiver {
 	// Defines our event interface for communication
 	public interface Receiver {
 		public void onReceiveResult(int resultCode, Bundle resultData);
+	}
+
+	// Setup the callback for when data is received from the service
+	public static MySimpleReceiver setupServiceReceiver(final Context context) {
+		MySimpleReceiver receiverForSimple = new MySimpleReceiver(new Handler());
+		// This is where we specify what happens when data is received from the
+		// service
+		receiverForSimple.setReceiver(new MySimpleReceiver.Receiver() {
+			@Override
+			public void onReceiveResult(int resultCode, Bundle resultData) {
+				if (resultCode == RESULT_OK) {
+					String resultValue = resultData.getString("resultValue");
+					Toast.makeText(context, resultValue, Toast.LENGTH_SHORT).show();
+				}
+			}
+		});
+		return receiverForSimple;
 	}
 
 	// Delegate method which passes the result to the receiver if the receiver

--- a/app/src/main/java/com/codepath/example/servicesnotificationsdemo/services/ImageDownloadService.java
+++ b/app/src/main/java/com/codepath/example/servicesnotificationsdemo/services/ImageDownloadService.java
@@ -16,6 +16,7 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.JobIntentService;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.RemoteInput;
+import android.util.Log;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,6 +45,8 @@ public class ImageDownloadService extends JobIntentService {
     // Download the image and create notification
     @Override
     protected void onHandleWork(@NonNull Intent intent) {
+        Log.d("DEBUG", "ImageDownloadService triggered");
+
         // Extract additional values from the bundle
         String imageUrl = intent.getStringExtra("url");
         // Download image

--- a/app/src/main/java/com/codepath/example/servicesnotificationsdemo/services/ImageDownloadService.java
+++ b/app/src/main/java/com/codepath/example/servicesnotificationsdemo/services/ImageDownloadService.java
@@ -12,6 +12,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.RemoteInput;
 
@@ -25,20 +27,23 @@ import static android.app.PendingIntent.FLAG_CANCEL_CURRENT;
 import static com.codepath.example.servicesnotificationsdemo.services.DirectReplyIntent.KEY_NOTIFY_ID;
 import static com.codepath.example.servicesnotificationsdemo.services.DirectReplyIntent.KEY_TEXT_REPLY;
 
-public class ImageDownloadService extends IntentService {
+public class ImageDownloadService extends JobIntentService {
+    public static final int JOB_ID = 101;
 
     public static final int NOTIF_ID = 82;
 
-    long timestamp;
+    public static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, ImageDownloadService.class, JOB_ID, work);
+    }
 
     // Must create a default constructor
     public ImageDownloadService() {
-        super("image-service");
+        super();
     }
 
     // Download the image and create notification
     @Override
-    protected void onHandleIntent(Intent intent) {
+    protected void onHandleWork(@NonNull Intent intent) {
         // Extract additional values from the bundle
         String imageUrl = intent.getStringExtra("url");
         // Download image

--- a/app/src/main/java/com/codepath/example/servicesnotificationsdemo/services/MySimpleService.java
+++ b/app/src/main/java/com/codepath/example/servicesnotificationsdemo/services/MySimpleService.java
@@ -12,6 +12,7 @@ import android.os.ResultReceiver;
 import android.support.annotation.NonNull;
 import android.support.v4.app.JobIntentService;
 import android.support.v4.app.NotificationCompat;
+import android.util.Log;
 
 import com.codepath.example.servicesnotificationsdemo.DemoApplication;
 import com.codepath.example.servicesnotificationsdemo.R;
@@ -29,11 +30,13 @@ public class MySimpleService extends JobIntentService {
 	// This describes what will happen when service is triggered
 	@Override
 	protected void onHandleWork(@NonNull Intent intent) {
+		Log.d("DEBUG", "MySimpleService triggered");
 		timestamp =  System.currentTimeMillis();
 	    // Extract additional values from the bundle
 	    String val = intent.getStringExtra("foo");
 		// Extract the receiver passed into the service
 	    ResultReceiver rec = intent.getParcelableExtra("receiver");
+
 	    // Sleep a bit first
 	    sleep(3000);
 	    // Send result to activity

--- a/app/src/main/java/com/codepath/example/servicesnotificationsdemo/services/MySimpleService.java
+++ b/app/src/main/java/com/codepath/example/servicesnotificationsdemo/services/MySimpleService.java
@@ -9,24 +9,26 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.ResultReceiver;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
 import android.support.v4.app.NotificationCompat;
 
 import com.codepath.example.servicesnotificationsdemo.DemoApplication;
 import com.codepath.example.servicesnotificationsdemo.R;
 import com.codepath.example.servicesnotificationsdemo.activities.MainActivity;
 
-public class MySimpleService extends IntentService {
+public class MySimpleService extends JobIntentService {
+	public static final int JOB_ID = 100;
 	public static final int NOTIF_ID = 56;
 	long timestamp;
-	
-	// Must create a default constructor
-	public MySimpleService() {
-		super("simple-service");
+
+	public static void enqueueWork(Context context, Intent work) {
+		enqueueWork(context, MySimpleService.class, JOB_ID, work);
 	}
-   
+
 	// This describes what will happen when service is triggered
 	@Override
-	protected void onHandleIntent(Intent intent) {
+	protected void onHandleWork(@NonNull Intent intent) {
 		timestamp =  System.currentTimeMillis();
 	    // Extract additional values from the bundle
 	    String val = intent.getStringExtra("foo");


### PR DESCRIPTION
* IntentService -> JobIntentService
     - For API 26 and above, this will dispatch tasks through the JobScheduler.  For older versions, it will use IntentServices under the covers.

* Fix crashing when dispatching AlarmManager dispatching since we are passing around the receiver reference -- instantiate it whenever we need to create one with setupServiceReceiver().

* AlarmManager doesn't seem to fire except after every 60000 (60 seconds) -- this seems to be have changed since API 19 and the IDE complains to you if you try to set an exact timer.